### PR TITLE
Fixed the quality of generated plans

### DIFF
--- a/autoplan/phases/combine_steps.py
+++ b/autoplan/phases/combine_steps.py
@@ -32,7 +32,13 @@ async def combine_steps(
         messages=messages,
         **context.combine_steps_llm_args,
         temperature=temperature,
-        response_format=context.output_model,
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "schema": context.output_model.model_json_schema(),
+                "name": context.output_model.__name__,
+            },
+        },
     )
 
     # asserts are for type checking, and reflect invariants we expect from the acompletion function


### PR DESCRIPTION
I figured that the quality of generated plans were pretty poor -- something we have notced in the past but never deeply diagonosed.
I observed that this was due to 2 root causes:

The streaming API with tool calls doesn't return the same quality of output compared to the completion API with structured response format. They were meant to be doing the same thing, but the results are really not the same.
The json schema generated by the combilnation of LiteLLM and Pydantic isn't always correct. To fix that, we need to write that schema specification at a lower level. Here is a relevant discussion thread: https://github.com/i-am-bee/beeai-framework/issues/588
I think the code should be improved from here:
Factorize the use of this serialization so it can be easily used elsewhere, in particular by the tools as well.
Reactivate the streaming API for the plan generation.
